### PR TITLE
feat: AuthenticationUseCaseの実装

### DIFF
--- a/packages/backend/src/application/errors/application-error.ts
+++ b/packages/backend/src/application/errors/application-error.ts
@@ -1,0 +1,31 @@
+export type ApplicationErrorType = 
+  | 'VALIDATION'
+  | 'UNAUTHORIZED'
+  | 'FORBIDDEN'
+  | 'NOT_FOUND'
+  | 'CONFLICT'
+  | 'RATE_LIMIT'
+  | 'EXTERNAL_SERVICE'
+  | 'INTERNAL';
+
+export class ApplicationError extends Error {
+  constructor(
+    public readonly code: string,
+    public readonly message: string,
+    public readonly type: ApplicationErrorType,
+    public readonly metadata?: Record<string, any>
+  ) {
+    super(message);
+    this.name = 'ApplicationError';
+    Object.setPrototypeOf(this, ApplicationError.prototype);
+  }
+
+  toJSON() {
+    return {
+      code: this.code,
+      message: this.message,
+      type: this.type,
+      metadata: this.metadata,
+    };
+  }
+}

--- a/packages/backend/src/application/errors/result.ts
+++ b/packages/backend/src/application/errors/result.ts
@@ -1,0 +1,31 @@
+import { ApplicationError } from './application-error';
+
+export interface SuccessResult<T> {
+  success: true;
+  data: T;
+  error?: never;
+}
+
+export interface ErrorResult {
+  success: false;
+  data?: never;
+  error: ApplicationError;
+}
+
+export type Result<T> = SuccessResult<T> | ErrorResult;
+
+export class ApplicationResult {
+  static ok<T>(data: T): SuccessResult<T> {
+    return {
+      success: true,
+      data,
+    };
+  }
+
+  static fail(error: ApplicationError): ErrorResult {
+    return {
+      success: false,
+      error,
+    };
+  }
+}

--- a/packages/backend/src/application/index.ts
+++ b/packages/backend/src/application/index.ts
@@ -1,0 +1,15 @@
+// Errors
+export { ApplicationError } from './errors/application-error';
+export type { ApplicationErrorType } from './errors/application-error';
+export { ApplicationResult } from './errors/result';
+export type { Result, SuccessResult, ErrorResult } from './errors/result';
+
+// Use Cases
+export { AuthenticationUseCase } from './use-cases/authentication.use-case';
+
+// Interfaces
+export type { 
+  IAuthenticationUseCase,
+  TokenRefreshResult,
+  TokenValidationResult 
+} from './interfaces/authentication-use-case.interface';

--- a/packages/backend/src/application/interfaces/authentication-use-case.interface.ts
+++ b/packages/backend/src/application/interfaces/authentication-use-case.interface.ts
@@ -1,0 +1,38 @@
+import { Result } from '../errors/result';
+import { AuthenticatedUser } from '@/domain/auth/value-objects/authenticated-user';
+
+export interface TokenRefreshResult {
+  accessToken: string;
+  refreshToken: string;
+  expiresIn: number;
+  userId: string;
+  tier: string;
+}
+
+export interface TokenValidationResult {
+  user: AuthenticatedUser;
+  tokenId?: string;
+}
+
+export interface IAuthenticationUseCase {
+  /**
+   * Validates an access token and returns the authenticated user
+   * @param token The JWT access token to validate
+   * @returns The authenticated user if valid, or an error
+   */
+  validateToken(token: string): Promise<Result<TokenValidationResult>>;
+
+  /**
+   * Refreshes an access token using a refresh token
+   * @param refreshToken The refresh token
+   * @returns New tokens if successful, or an error
+   */
+  refreshToken(refreshToken: string): Promise<Result<TokenRefreshResult>>;
+
+  /**
+   * Signs out a user, invalidating all their sessions
+   * @param userId The user ID to sign out
+   * @returns Success or error result
+   */
+  signOut(userId: string): Promise<Result<void>>;
+}

--- a/packages/backend/src/application/use-cases/__tests__/authentication.use-case.test.ts
+++ b/packages/backend/src/application/use-cases/__tests__/authentication.use-case.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { AuthenticationUseCase } from '../authentication.use-case';
+import { IAuthAdapter } from '@/infrastructure/auth/interfaces/auth-adapter.interface';
+import { AuthenticationService } from '@/domain/auth/services/authentication.service';
+import { IEventBus } from '@/domain/interfaces/event-bus.interface';
+import { AuthenticatedUser } from '@/domain/auth/value-objects/authenticated-user';
+import { UserId } from '@/domain/auth/value-objects/user-id';
+import { UserTier } from '@/domain/auth/value-objects/user-tier';
+import { TierLevel } from '@/domain/auth/value-objects/tier-level';
+import { Result as DomainResult } from '@/domain/shared/result';
+import { TokenPayload } from '@/domain/auth/types/token-payload';
+import { Session } from '@/infrastructure/auth/interfaces/auth-adapter.interface';
+import type { Logger } from 'pino';
+
+describe('AuthenticationUseCase', () => {
+  let useCase: AuthenticationUseCase;
+  let mockAuthAdapter: IAuthAdapter;
+  let mockAuthService: AuthenticationService;
+  let mockEventBus: IEventBus;
+  let mockLogger: Logger;
+
+  const validUuid = '550e8400-e29b-41d4-a716-446655440000';
+
+  beforeEach(() => {
+    mockAuthAdapter = {
+      verifyToken: vi.fn(),
+      refreshAccessToken: vi.fn(),
+      signOut: vi.fn(),
+    };
+
+    mockAuthService = {
+      validateToken: vi.fn(),
+    } as any;
+
+    mockEventBus = {
+      publish: vi.fn(),
+      subscribe: vi.fn(),
+      unsubscribe: vi.fn(),
+    };
+
+    mockLogger = {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    } as any;
+
+    useCase = new AuthenticationUseCase(
+      mockAuthAdapter,
+      mockAuthService,
+      mockEventBus,
+      mockLogger
+    );
+  });
+
+  describe('validateToken', () => {
+    it('should successfully validate a valid token', async () => {
+      const token = 'valid.jwt.token';
+      const tokenPayload: TokenPayload = {
+        sub: validUuid,
+        email: 'test@example.com',
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        app_metadata: { tier: 'tier2' },
+        user_metadata: {},
+        jti: 'token-id-123',
+      };
+
+      const authenticatedUser = new AuthenticatedUser(
+        UserId.fromString(validUuid),
+        UserTier.createDefault(TierLevel.TIER2)
+      );
+
+      vi.mocked(mockAuthAdapter.verifyToken).mockResolvedValue(tokenPayload);
+      vi.mocked(mockAuthService.validateToken).mockReturnValue(
+        DomainResult.ok(authenticatedUser)
+      );
+
+      const result = await useCase.validateToken(token);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.user).toBe(authenticatedUser);
+        expect(result.data.tokenId).toBe('token-id-123');
+      }
+      expect(mockAuthAdapter.verifyToken).toHaveBeenCalledWith(token);
+      expect(mockAuthService.validateToken).toHaveBeenCalledWith(tokenPayload);
+      expect(mockEventBus.publish).not.toHaveBeenCalled();
+    });
+
+    it('should fail for empty token', async () => {
+      const result = await useCase.validateToken('');
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.code).toBe('INVALID_TOKEN_FORMAT');
+        expect(result.error.type).toBe('VALIDATION');
+      }
+      expect(mockAuthAdapter.verifyToken).not.toHaveBeenCalled();
+    });
+
+    it('should fail when token verification fails', async () => {
+      const token = 'invalid.jwt.token';
+
+      vi.mocked(mockAuthAdapter.verifyToken).mockResolvedValue(null);
+
+      const result = await useCase.validateToken(token);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.code).toBe('TOKEN_VERIFICATION_FAILED');
+        expect(result.error.type).toBe('UNAUTHORIZED');
+      }
+      expect(mockEventBus.publish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          reason: 'JWT_VERIFICATION_FAILED',
+        })
+      );
+    });
+
+    it('should fail when domain validation fails', async () => {
+      const token = 'valid.jwt.token';
+      const tokenPayload: TokenPayload = {
+        sub: validUuid,
+        email: 'test@example.com',
+        iat: Math.floor(Date.now() / 1000),
+        exp: Math.floor(Date.now() / 1000) - 3600, // Expired
+        app_metadata: { tier: 'tier1' },
+        user_metadata: {},
+      };
+
+      vi.mocked(mockAuthAdapter.verifyToken).mockResolvedValue(tokenPayload);
+      vi.mocked(mockAuthService.validateToken).mockReturnValue(
+        DomainResult.fail(new Error('Token expired'))
+      );
+
+      const result = await useCase.validateToken(token);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.code).toBe('TOKEN_VALIDATION_FAILED');
+        expect(result.error.type).toBe('UNAUTHORIZED');
+      }
+      expect(mockEventBus.publish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          aggregateId: validUuid,
+          provider: validUuid,
+          reason: 'Token expired',
+        })
+      );
+    });
+  });
+
+  describe('refreshToken', () => {
+    it('should successfully refresh a valid token', async () => {
+      const refreshToken = 'valid.refresh.token';
+      const session: Session = {
+        access_token: 'new.access.token',
+        refresh_token: 'new.refresh.token',
+        expires_in: 3600,
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        token_type: 'bearer',
+        user: {
+          id: validUuid,
+          email: 'test@example.com',
+          app_metadata: { tier: 'tier2' },
+          user_metadata: {},
+        },
+      };
+
+      vi.mocked(mockAuthAdapter.refreshAccessToken).mockResolvedValue(session);
+
+      const result = await useCase.refreshToken(refreshToken);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.accessToken).toBe('new.access.token');
+        expect(result.data.refreshToken).toBe('new.refresh.token');
+        expect(result.data.expiresIn).toBe(3600);
+        expect(result.data.userId).toBe(validUuid);
+        expect(result.data.tier).toBe('tier2');
+      }
+      expect(mockAuthAdapter.refreshAccessToken).toHaveBeenCalledWith(refreshToken);
+      expect(mockEventBus.publish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          aggregateId: validUuid,
+          userId: validUuid,
+        })
+      );
+    });
+
+    it('should fail for empty refresh token', async () => {
+      const result = await useCase.refreshToken('');
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.code).toBe('INVALID_REFRESH_TOKEN_FORMAT');
+        expect(result.error.type).toBe('VALIDATION');
+      }
+      expect(mockAuthAdapter.refreshAccessToken).not.toHaveBeenCalled();
+    });
+
+    it('should fail when refresh token is invalid', async () => {
+      const refreshToken = 'invalid.refresh.token';
+
+      vi.mocked(mockAuthAdapter.refreshAccessToken).mockResolvedValue(null);
+
+      const result = await useCase.refreshToken(refreshToken);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.code).toBe('REFRESH_TOKEN_INVALID');
+        expect(result.error.type).toBe('UNAUTHORIZED');
+      }
+    });
+
+    it('should default to tier1 when tier is not specified', async () => {
+      const refreshToken = 'valid.refresh.token';
+      const session: Session = {
+        access_token: 'new.access.token',
+        refresh_token: 'new.refresh.token',
+        expires_in: 3600,
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+        token_type: 'bearer',
+        user: {
+          id: validUuid,
+          email: 'test@example.com',
+          app_metadata: {}, // No tier specified
+          user_metadata: {},
+        },
+      };
+
+      vi.mocked(mockAuthAdapter.refreshAccessToken).mockResolvedValue(session);
+
+      const result = await useCase.refreshToken(refreshToken);
+
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.tier).toBe('tier1');
+      }
+    });
+  });
+
+  describe('signOut', () => {
+    it('should successfully sign out a user', async () => {
+      vi.mocked(mockAuthAdapter.signOut).mockResolvedValue(undefined);
+
+      const result = await useCase.signOut(validUuid);
+
+      expect(result.success).toBe(true);
+      expect(mockAuthAdapter.signOut).toHaveBeenCalledWith(validUuid);
+      expect(mockEventBus.publish).toHaveBeenCalledWith(
+        expect.objectContaining({
+          aggregateId: validUuid,
+          userId: validUuid,
+          reason: 'user_initiated',
+        })
+      );
+    });
+
+    it('should fail for empty user ID', async () => {
+      const result = await useCase.signOut('');
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.code).toBe('INVALID_USER_ID');
+        expect(result.error.type).toBe('VALIDATION');
+      }
+      expect(mockAuthAdapter.signOut).not.toHaveBeenCalled();
+    });
+
+    it('should handle sign out errors', async () => {
+      vi.mocked(mockAuthAdapter.signOut).mockRejectedValue(
+        new Error('Network error')
+      );
+
+      const result = await useCase.signOut(validUuid);
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.code).toBe('INTERNAL_ERROR');
+        expect(result.error.type).toBe('INTERNAL');
+      }
+      expect(mockLogger.error).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/backend/src/application/use-cases/authentication.use-case.ts
+++ b/packages/backend/src/application/use-cases/authentication.use-case.ts
@@ -1,0 +1,245 @@
+import { injectable, inject } from 'tsyringe';
+import { IAuthenticationUseCase, TokenRefreshResult, TokenValidationResult } from '../interfaces/authentication-use-case.interface';
+import { Result } from '../errors/result';
+import { ApplicationError } from '../errors/application-error';
+import { ApplicationResult } from '../errors/result';
+import { IAuthAdapter } from '@/infrastructure/auth/interfaces/auth-adapter.interface';
+import { AuthenticationService } from '@/domain/auth/services/authentication.service';
+import { AuthenticatedUser } from '@/domain/auth/value-objects/authenticated-user';
+import { IEventBus } from '@/domain/interfaces/event-bus.interface';
+import { TokenRefreshed } from '@/domain/auth/events/token-refreshed.event';
+import { AuthenticationFailed } from '@/domain/auth/events/authentication-failed.event';
+import { UserLoggedOut } from '@/domain/auth/events/user-logged-out.event';
+import { CorrelationId } from '@/domain/shared/value-objects/correlation-id';
+import { Logger } from 'pino';
+import { DI_TOKENS } from '@/infrastructure/di/tokens';
+
+@injectable()
+export class AuthenticationUseCase implements IAuthenticationUseCase {
+  constructor(
+    @inject(DI_TOKENS.AuthAdapter)
+    private readonly authAdapter: IAuthAdapter,
+    @inject(DI_TOKENS.AuthenticationService)
+    private readonly authService: AuthenticationService,
+    @inject(DI_TOKENS.EventBus)
+    private readonly eventBus: IEventBus,
+    @inject(DI_TOKENS.Logger)
+    private readonly logger: Logger
+  ) {}
+
+  async validateToken(token: string): Promise<Result<TokenValidationResult>> {
+    try {
+      // Validate token format
+      if (!token || typeof token !== 'string' || token.trim().length === 0) {
+        return ApplicationResult.fail(
+          new ApplicationError(
+            'INVALID_TOKEN_FORMAT',
+            'Token format is invalid',
+            'VALIDATION'
+          )
+        );
+      }
+
+      // Verify token with auth adapter
+      const tokenPayload = await this.authAdapter.verifyToken(token);
+      
+      if (!tokenPayload) {
+        // Log authentication failure event
+        const failureEvent = new AuthenticationFailed(
+          'system',
+          1,
+          'unknown',
+          'JWT_VERIFICATION_FAILED',
+          token.substring(0, 10) + '...'
+        );
+        await this.eventBus.publish(failureEvent);
+
+        return ApplicationResult.fail(
+          new ApplicationError(
+            'TOKEN_VERIFICATION_FAILED',
+            'Token verification failed',
+            'UNAUTHORIZED'
+          )
+        );
+      }
+
+      // Validate with domain service
+      const validationResult = this.authService.validateToken(tokenPayload);
+      
+      if (validationResult.isFailure) {
+        const error = validationResult.getError();
+        
+        // Log authentication failure event
+        const failureEvent = new AuthenticationFailed(
+          tokenPayload.sub || 'unknown',
+          1,
+          tokenPayload.sub || 'unknown',
+          error.message
+        );
+        await this.eventBus.publish(failureEvent);
+
+        return ApplicationResult.fail(
+          new ApplicationError(
+            'TOKEN_VALIDATION_FAILED',
+            error.message,
+            'UNAUTHORIZED'
+          )
+        );
+      }
+
+      const authenticatedUser = validationResult.getValue();
+
+      this.logger.info({
+        userId: authenticatedUser.userId.value,
+        tier: authenticatedUser.tier.level,
+      }, 'Token validated successfully');
+
+      return ApplicationResult.ok({
+        user: authenticatedUser,
+        tokenId: tokenPayload.jti,
+      });
+
+    } catch (error) {
+      this.logger.error({
+        error: error instanceof Error ? error.message : 'Unknown error',
+        stack: error instanceof Error ? error.stack : undefined,
+      }, 'Unexpected error during token validation');
+
+      return ApplicationResult.fail(
+        new ApplicationError(
+          'INTERNAL_ERROR',
+          'An unexpected error occurred during token validation',
+          'INTERNAL'
+        )
+      );
+    }
+  }
+
+  async refreshToken(refreshToken: string): Promise<Result<TokenRefreshResult>> {
+    try {
+      // Validate refresh token format
+      if (!refreshToken || typeof refreshToken !== 'string' || refreshToken.trim().length === 0) {
+        return ApplicationResult.fail(
+          new ApplicationError(
+            'INVALID_REFRESH_TOKEN_FORMAT',
+            'Refresh token format is invalid',
+            'VALIDATION'
+          )
+        );
+      }
+
+      // Refresh token with auth adapter
+      const session = await this.authAdapter.refreshAccessToken(refreshToken);
+      
+      if (!session) {
+        return ApplicationResult.fail(
+          new ApplicationError(
+            'REFRESH_TOKEN_INVALID',
+            'Invalid or expired refresh token',
+            'UNAUTHORIZED'
+          )
+        );
+      }
+
+      // Extract token IDs if available
+      let oldTokenId: string | undefined;
+      let newTokenId: string | undefined;
+      
+      try {
+        // Try to decode tokens to get JTI claims
+        const jwt = await import('jsonwebtoken');
+        const decoded = jwt.decode(session.access_token) as any;
+        newTokenId = decoded?.jti;
+      } catch (e) {
+        // If we can't decode, that's ok - token IDs are optional
+      }
+
+      // Publish token refreshed event
+      const refreshEvent = new TokenRefreshed(
+        session.user.id,
+        1,
+        session.user.id,
+        oldTokenId,
+        newTokenId,
+        1, // First refresh
+        refreshToken.substring(0, 10) // Session ID proxy
+      );
+      await this.eventBus.publish(refreshEvent);
+
+      this.logger.info({
+        userId: session.user.id,
+        tier: session.user.app_metadata?.tier || 'tier1',
+      }, 'Token refreshed successfully');
+
+      return ApplicationResult.ok({
+        accessToken: session.access_token,
+        refreshToken: session.refresh_token,
+        expiresIn: session.expires_in,
+        userId: session.user.id,
+        tier: session.user.app_metadata?.tier || 'tier1',
+      });
+
+    } catch (error) {
+      this.logger.error({
+        error: error instanceof Error ? error.message : 'Unknown error',
+        stack: error instanceof Error ? error.stack : undefined,
+      }, 'Unexpected error during token refresh');
+
+      return ApplicationResult.fail(
+        new ApplicationError(
+          'INTERNAL_ERROR',
+          'An unexpected error occurred during token refresh',
+          'INTERNAL'
+        )
+      );
+    }
+  }
+
+  async signOut(userId: string): Promise<Result<void>> {
+    try {
+      // Validate user ID format
+      if (!userId || typeof userId !== 'string' || userId.trim().length === 0) {
+        return ApplicationResult.fail(
+          new ApplicationError(
+            'INVALID_USER_ID',
+            'User ID is invalid',
+            'VALIDATION'
+          )
+        );
+      }
+
+      // Sign out with auth adapter
+      await this.authAdapter.signOut(userId);
+
+      // Publish user logged out event
+      const logoutEvent = new UserLoggedOut(
+        userId,
+        1,
+        userId,
+        'user_initiated'
+      );
+      await this.eventBus.publish(logoutEvent);
+
+      this.logger.info({
+        userId,
+      }, 'User signed out successfully');
+
+      return ApplicationResult.ok(undefined);
+
+    } catch (error) {
+      this.logger.error({
+        error: error instanceof Error ? error.message : 'Unknown error',
+        stack: error instanceof Error ? error.stack : undefined,
+        userId,
+      }, 'Unexpected error during sign out');
+
+      return ApplicationResult.fail(
+        new ApplicationError(
+          'INTERNAL_ERROR',
+          'An unexpected error occurred during sign out',
+          'INTERNAL'
+        )
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- アプリケーション層の基盤となるAuthenticationUseCaseを実装
- JWTトークンの検証、リフレッシュ、サインアウト機能を提供
- 他のAPIエンドポイント実装の前提となる重要なコンポーネント

## Test plan
- [x] 単体テストが全て成功している（11テスト全てパス）
- [x] DIコンテナへの登録が正しく設定されている
- [x] エラーハンドリングが適切に実装されている

## Implementation details
- ApplicationError と Result 型によるエラーハンドリング
- IAuthenticationUseCase インターフェースの定義
- AuthenticationUseCase の実装
  - validateToken: Supabase Auth Adapterを使用したトークン検証
  - refreshToken: リフレッシュトークンによる新規アクセストークン取得
  - signOut: 全セッションの無効化
- イベント発行による監査ログとセキュリティ監視の連携
- DIコンテナへのサービス登録（EventBus、AuthenticationService、AuthenticationUseCase）

## Next steps
このUseCaseを使用して、以下のエンドポイントを実装可能になります：
- トークンリフレッシュエンドポイント（/api/auth/refresh）
- ログアウトエンドポイント（/api/auth/logout）
- 認証ミドルウェア

🤖 Generated with [Claude Code](https://claude.ai/code)