### PR TITLE
feat: implement token refresh endpoint (task-0017)

### DIFF
--- a/packages/backend/src/presentation/routes/auth/__tests__/refresh.route.test.ts
+++ b/packages/backend/src/presentation/routes/auth/__tests__/refresh.route.test.ts
@@ -1,0 +1,224 @@
+import 'reflect-metadata';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fastify, { FastifyInstance } from 'fastify';
+import { container } from 'tsyringe';
+import { setupTestDI } from '../../../../infrastructure/di';
+import refreshRoute from '../refresh.route';
+import { AuthenticationUseCase } from '../../../../application/use-cases/authentication.use-case';
+import { ApplicationError } from '../../../../application/errors/application-error';
+import { DI_TOKENS } from '../../../../infrastructure/di/tokens';
+import type { Result } from '../../../../application/errors/result';
+
+describe('Refresh Route', () => {
+  let app: FastifyInstance;
+  let mockAuthUseCase: Partial<AuthenticationUseCase>;
+
+  beforeEach(async () => {
+    setupTestDI();
+    
+    // Mock AuthenticationUseCase
+    mockAuthUseCase = {
+      refreshToken: vi.fn(),
+    };
+    
+    container.register(DI_TOKENS.AuthenticationUseCase, {
+      useValue: mockAuthUseCase,
+    });
+
+    app = fastify({ logger: false });
+    
+    // Register error handler to properly format validation errors
+    await app.register(import('../../../plugins/error-handler'));
+    
+    await app.register(refreshRoute);
+  });
+
+  afterEach(async () => {
+    await app.close();
+    vi.clearAllMocks();
+  });
+
+  describe('POST /refresh', () => {
+    it('should refresh token successfully', async () => {
+      const mockRefreshResult = {
+        accessToken: 'new-access-token',
+        refreshToken: 'new-refresh-token',
+        expiresIn: 3600,
+      };
+
+      vi.mocked(mockAuthUseCase.refreshToken).mockResolvedValue({
+        success: true,
+        data: mockRefreshResult
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/refresh',
+        payload: {
+          refresh_token: 'valid-refresh-token',
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.headers['content-type']).toContain('application/json');
+      
+      const body = JSON.parse(response.body);
+      expect(body).toEqual({
+        access_token: 'new-access-token',
+        refresh_token: 'new-refresh-token',
+        expires_in: 3600,
+        token_type: 'bearer',
+      });
+
+      expect(mockAuthUseCase.refreshToken).toHaveBeenCalledWith('valid-refresh-token');
+    });
+
+    it('should return 400 when refresh token is missing', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/refresh',
+        payload: {},
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.headers['content-type']).toContain('application/problem+json');
+      
+      const body = JSON.parse(response.body);
+      expect(body).toMatchObject({
+        type: expect.stringContaining('/errors/validation-error'),
+        title: 'Validation Error',
+        status: 400,
+        instance: '/refresh',
+      });
+
+      expect(mockAuthUseCase.refreshToken).not.toHaveBeenCalled();
+    });
+
+    it('should return 401 when refresh token is empty', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/refresh',
+        payload: {
+          refresh_token: '   ',
+        },
+      });
+
+      expect(response.statusCode).toBe(401);
+      expect(response.headers['content-type']).toContain('application/problem+json');
+      
+      const body = JSON.parse(response.body);
+      expect(body).toMatchObject({
+        type: expect.stringContaining('/errors/missing-refresh-token'),
+        title: 'Refresh token is required',
+        status: 401,
+        instance: '/refresh',
+      });
+    });
+
+    it('should return 401 when refresh token is invalid', async () => {
+      const error = new ApplicationError(
+        'INVALID_REFRESH_TOKEN',
+        'Invalid or expired refresh token',
+        'UNAUTHORIZED'
+      );
+
+      vi.mocked(mockAuthUseCase.refreshToken).mockResolvedValue({
+        success: false,
+        error
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/refresh',
+        payload: {
+          refresh_token: 'invalid-token',
+        },
+      });
+
+      expect(response.statusCode).toBe(401);
+      expect(response.headers['content-type']).toContain('application/problem+json');
+      
+      const body = JSON.parse(response.body);
+      expect(body).toMatchObject({
+        type: expect.stringContaining('/errors/invalid-refresh-token'),
+        title: 'Invalid or expired refresh token',
+        status: 401,
+      });
+    });
+
+    it('should return 503 when external service fails', async () => {
+      const error = new ApplicationError(
+        'SUPABASE_ERROR',
+        'External service unavailable',
+        'EXTERNAL_SERVICE',
+        { service: 'supabase' }
+      );
+
+      vi.mocked(mockAuthUseCase.refreshToken).mockResolvedValue({
+        success: false,
+        error
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/refresh',
+        payload: {
+          refresh_token: 'valid-token',
+        },
+      });
+
+      expect(response.statusCode).toBe(503);
+      expect(response.headers['content-type']).toContain('application/problem+json');
+      
+      const body = JSON.parse(response.body);
+      expect(body).toMatchObject({
+        type: expect.stringContaining('/errors/supabase-error'),
+        title: 'External service unavailable',
+        status: 503,
+      });
+    });
+
+    it('should return 503 when unexpected error occurs', async () => {
+      vi.mocked(mockAuthUseCase.refreshToken).mockRejectedValue(
+        new Error('Unexpected error')
+      );
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/refresh',
+        payload: {
+          refresh_token: 'valid-token',
+        },
+      });
+
+      expect(response.statusCode).toBe(503);
+      expect(response.headers['content-type']).toContain('application/problem+json');
+      
+      const body = JSON.parse(response.body);
+      expect(body).toMatchObject({
+        type: expect.stringContaining('/errors/internal-error'),
+        title: 'An unexpected error occurred',
+        status: 503,
+      });
+    });
+
+    it('should validate request body schema', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/refresh',
+        payload: {
+          invalid_field: 'value',
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+      expect(response.headers['content-type']).toContain('application/problem+json');
+      
+      const body = JSON.parse(response.body);
+      expect(body).toMatchObject({
+        type: expect.stringContaining('/errors/validation-error'),
+        status: 400,
+      });
+    });
+  });
+});

--- a/packages/backend/src/presentation/routes/auth/index.ts
+++ b/packages/backend/src/presentation/routes/auth/index.ts
@@ -1,0 +1,16 @@
+import { FastifyPluginAsync } from 'fastify';
+import refreshRoute from './refresh.route';
+
+/**
+ * 認証関連のルートを登録するプラグイン
+ */
+const authRoutes: FastifyPluginAsync = async (fastify) => {
+  // トークンリフレッシュエンドポイント
+  await fastify.register(refreshRoute);
+  
+  // TODO: 後続タスクで以下のルートを追加
+  // - /auth/logout (task-0018)
+  // - その他の認証関連エンドポイント
+};
+
+export default authRoutes;

--- a/packages/backend/src/presentation/routes/auth/refresh.route.ts
+++ b/packages/backend/src/presentation/routes/auth/refresh.route.ts
@@ -1,0 +1,161 @@
+import { FastifyPluginAsync } from 'fastify';
+import { Static, Type } from '@sinclair/typebox';
+import { container } from 'tsyringe';
+import { AuthenticationUseCase } from '@/application/use-cases/authentication.use-case';
+import { toProblemDetails } from '@/presentation/errors/error-mapper';
+import { DI_TOKENS } from '@/infrastructure/di/tokens';
+
+// リクエストボディのスキーマ
+const RefreshTokenRequest = Type.Object({
+  refresh_token: Type.String({
+    description: 'The refresh token obtained from login or previous refresh',
+    minLength: 1,
+  }),
+});
+
+// レスポンスボディのスキーマ
+const RefreshTokenResponse = Type.Object({
+  access_token: Type.String({
+    description: 'New JWT access token',
+  }),
+  refresh_token: Type.String({
+    description: 'New refresh token',
+  }),
+  expires_in: Type.Number({
+    description: 'Token expiration time in seconds',
+  }),
+  token_type: Type.Literal('bearer'),
+});
+
+// エラーレスポンスのスキーマ
+const ErrorResponse = Type.Object({
+  type: Type.String(),
+  title: Type.String(),
+  status: Type.Number(),
+  detail: Type.Optional(Type.String()),
+  instance: Type.String(),
+});
+
+type RefreshTokenRequestType = Static<typeof RefreshTokenRequest>;
+type RefreshTokenResponseType = Static<typeof RefreshTokenResponse>;
+
+const refreshRoute: FastifyPluginAsync = async (fastify) => {
+  const authUseCase = container.resolve<AuthenticationUseCase>(DI_TOKENS.AuthenticationUseCase);
+
+  fastify.post<{
+    Body: RefreshTokenRequestType;
+    Reply: RefreshTokenResponseType | Static<typeof ErrorResponse>;
+  }>(
+    '/refresh',
+    {
+      schema: {
+        description: 'Refresh access token using refresh token',
+        tags: ['Authentication'],
+        body: RefreshTokenRequest,
+        response: {
+          200: {
+            description: 'Token refreshed successfully',
+            ...RefreshTokenResponse,
+          },
+          401: {
+            description: 'Invalid or expired refresh token',
+            ...ErrorResponse,
+          },
+          503: {
+            description: 'Service unavailable',
+            ...ErrorResponse,
+          },
+        },
+      },
+      // このエンドポイントは認証不要（refresh tokenで認証）
+      config: {
+        requireAuth: false,
+      },
+    },
+    async (request, reply) => {
+      const { refresh_token } = request.body;
+      
+      request.log.info({
+        hasRefreshToken: !!refresh_token,
+        tokenLength: refresh_token?.length,
+      }, 'Token refresh request received');
+
+      try {
+        // リフレッシュトークンの基本検証
+        if (!refresh_token || refresh_token.trim().length === 0) {
+          const problemDetails = toProblemDetails(
+            {
+              code: 'MISSING_REFRESH_TOKEN',
+              message: 'Refresh token is required',
+              type: 'UNAUTHORIZED',
+            },
+            request.url
+          );
+          
+          return reply
+            .code(401)
+            .header('content-type', 'application/problem+json')
+            .send(problemDetails);
+        }
+
+        // トークンリフレッシュ処理
+        const result = await authUseCase.refreshToken(refresh_token);
+
+        if (!result.success) {
+          const problemDetails = toProblemDetails(
+            result.error,
+            request.url
+          );
+          
+          request.log.warn({
+            error: result.error?.code,
+            message: result.error?.message,
+          }, 'Token refresh failed');
+
+          // エラーの種類によってステータスコードを決定
+          const statusCode = result.error?.type === 'EXTERNAL_SERVICE' ? 503 : 401;
+          
+          return reply
+            .code(statusCode)
+            .header('content-type', 'application/problem+json')
+            .send(problemDetails);
+        }
+
+        request.log.info({
+          expiresIn: result.data.expiresIn,
+        }, 'Token refreshed successfully');
+
+        // 成功レスポンス
+        const response: RefreshTokenResponseType = {
+          access_token: result.data.accessToken,
+          refresh_token: result.data.refreshToken,
+          expires_in: result.data.expiresIn,
+          token_type: 'bearer',
+        };
+
+        return reply.send(response);
+      } catch (error) {
+        request.log.error({
+          error: error instanceof Error ? error.message : 'Unknown error',
+          stack: error instanceof Error ? error.stack : undefined,
+        }, 'Unexpected error during token refresh');
+
+        const problemDetails = toProblemDetails(
+          {
+            code: 'INTERNAL_ERROR',
+            message: 'An unexpected error occurred',
+            type: 'EXTERNAL_SERVICE',
+          },
+          request.url
+        );
+
+        return reply
+          .code(503)
+          .header('content-type', 'application/problem+json')
+          .send(problemDetails);
+      }
+    }
+  );
+};
+
+export default refreshRoute;

--- a/packages/backend/src/presentation/routes/index.ts
+++ b/packages/backend/src/presentation/routes/index.ts
@@ -1,0 +1,17 @@
+import { FastifyPluginAsync } from 'fastify';
+import authRoutes from './auth';
+
+/**
+ * APIルートを登録するプラグイン
+ * すべてのルートは /api/v1 プレフィックスを持つ
+ */
+const apiRoutes: FastifyPluginAsync = async (fastify) => {
+  // 認証関連のルート (/api/v1/auth/*)
+  await fastify.register(authRoutes, { prefix: '/auth' });
+  
+  // TODO: 後続タスクで以下のルートを追加
+  // - /api/v1/data/* (task-0024)
+  // - その他のAPIエンドポイント
+};
+
+export default apiRoutes;

--- a/packages/backend/src/presentation/types/fastify.d.ts
+++ b/packages/backend/src/presentation/types/fastify.d.ts
@@ -1,0 +1,12 @@
+import { AuthenticatedUser } from '@/domain/auth/value-objects/authenticated-user';
+
+declare module 'fastify' {
+  interface FastifyRequest {
+    user?: AuthenticatedUser;
+    authenticatedUser?: AuthenticatedUser;
+  }
+  
+  interface FastifyContextConfig {
+    requireAuth?: boolean;
+  }
+}

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -26,6 +26,9 @@ await server.register(import('./presentation/plugins/security-headers'));
 await server.register(import('./presentation/plugins/path-validation'));
 await server.register(import('./presentation/plugins/error-handler'));
 
+// APIルートの登録
+await server.register(import('./presentation/routes'), { prefix: '/api/v1' });
+
 server.get('/health', async () => {
   return { 
     status: 'ok', 


### PR DESCRIPTION
## Summary
- Implemented POST /api/v1/auth/refresh endpoint for JWT token refresh functionality
- Added comprehensive integration tests ensuring proper error handling
- Integrated with existing AuthenticationUseCase for token validation and refresh

## Implementation Details
- Created `refresh.route.ts` with Fastify route handler
- Used TypeBox for request/response schema validation
- Implemented RFC 7807 Problem Details format for error responses
- Added proper content-type headers for problem+json responses
- Updated error mapper to handle ApplicationError types
- Created auth routes index to organize authentication endpoints
- Registered routes in main server application under /api/v1 prefix

## Test Plan
- [x] All unit tests pass (7 tests)
- [x] Token refresh with valid refresh token returns new tokens
- [x] Missing refresh token returns 400 validation error
- [x] Empty refresh token returns 401 unauthorized
- [x] Invalid refresh token returns 401 with proper error format
- [x] External service errors return 503 service unavailable
- [x] Unexpected errors are handled gracefully

## Related
- Implements task-0017 from the implementation plan
- Uses AuthenticationUseCase from previous task
- Follows established error handling patterns

🤖 Generated with [Claude Code](https://claude.ai/code)