### PR TITLE
feat: implement logout endpoint and authentication middleware (task-0018)

### DIFF
--- a/packages/backend/src/presentation/middleware/__tests__/authenticate.test.ts
+++ b/packages/backend/src/presentation/middleware/__tests__/authenticate.test.ts
@@ -1,0 +1,187 @@
+import 'reflect-metadata';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { FastifyRequest, FastifyReply } from 'fastify';
+import { container } from 'tsyringe';
+import { authenticate } from '../authenticate';
+import { AuthenticationUseCase } from '@/application/use-cases/authentication.use-case';
+import { ApplicationError } from '@/application/errors/application-error';
+import { DI_TOKENS } from '@/infrastructure/di/tokens';
+import { setupTestDI } from '@/infrastructure/di';
+import { AuthenticatedUser } from '@/domain/auth/value-objects/authenticated-user';
+import { UserId } from '@/domain/auth/value-objects/user-id';
+import { UserTier } from '@/domain/auth/value-objects/user-tier';
+
+describe('authenticate middleware', () => {
+  let mockRequest: Partial<FastifyRequest>;
+  let mockReply: Partial<FastifyReply>;
+  let mockAuthUseCase: Partial<AuthenticationUseCase>;
+  
+  function createMockAuthenticatedUser(userId = 'test-user-123'): AuthenticatedUser {
+    return new AuthenticatedUser(
+      new UserId(userId),
+      new UserTier('tier1')
+    );
+  }
+
+  beforeEach(() => {
+    setupTestDI();
+    
+    // Mock request
+    mockRequest = {
+      headers: {},
+      url: '/test',
+      log: {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      } as any,
+    };
+    
+    // Mock reply
+    mockReply = {
+      code: vi.fn().mockReturnThis(),
+      header: vi.fn().mockReturnThis(),
+      send: vi.fn().mockReturnThis(),
+    };
+    
+    // Mock AuthenticationUseCase
+    mockAuthUseCase = {
+      validateToken: vi.fn(),
+    };
+    
+    container.register(DI_TOKENS.AuthenticationUseCase, {
+      useValue: mockAuthUseCase,
+    });
+  });
+
+  it('should authenticate successfully with valid token', async () => {
+    const mockUser = createMockAuthenticatedUser();
+    mockRequest.headers = {
+      authorization: 'Bearer valid-token',
+    };
+    
+    vi.mocked(mockAuthUseCase.validateToken).mockResolvedValue({
+      success: true,
+      data: {
+        user: mockUser,
+        tokenId: 'token-123'
+      }
+    });
+
+    await authenticate(mockRequest as FastifyRequest, mockReply as FastifyReply);
+
+    expect(mockAuthUseCase.validateToken).toHaveBeenCalledWith('valid-token');
+    expect(mockRequest.user).toBe(mockUser);
+    expect(mockRequest.authenticatedUser).toBe(mockUser);
+    expect(mockReply.send).not.toHaveBeenCalled();
+    expect(mockRequest.log.info).toHaveBeenCalledWith(
+      {
+        userId: 'test-user-123',
+        tier: 'tier1',
+      },
+      'User authenticated successfully'
+    );
+  });
+
+  it('should return 401 when authorization header is missing', async () => {
+    await authenticate(mockRequest as FastifyRequest, mockReply as FastifyReply);
+
+    expect(mockReply.code).toHaveBeenCalledWith(401);
+    expect(mockReply.header).toHaveBeenCalledWith('content-type', 'application/problem+json');
+    expect(mockReply.header).toHaveBeenCalledWith('www-authenticate', 'Bearer');
+    expect(mockReply.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: expect.stringContaining('/errors/missing-auth-header'),
+        title: 'Missing or invalid authorization header',
+        status: 401,
+      })
+    );
+    expect(mockAuthUseCase.validateToken).not.toHaveBeenCalled();
+  });
+
+  it('should return 401 when authorization header format is invalid', async () => {
+    mockRequest.headers = {
+      authorization: 'InvalidFormat token',
+    };
+
+    await authenticate(mockRequest as FastifyRequest, mockReply as FastifyReply);
+
+    expect(mockReply.code).toHaveBeenCalledWith(401);
+    expect(mockReply.header).toHaveBeenCalledWith('www-authenticate', 'Bearer');
+    expect(mockReply.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: expect.stringContaining('/errors/invalid-auth-format'),
+        title: 'Authorization header must use Bearer scheme',
+        status: 401,
+      })
+    );
+  });
+
+  it('should return 401 when token validation fails', async () => {
+    mockRequest.headers = {
+      authorization: 'Bearer invalid-token',
+    };
+    
+    const error = new ApplicationError(
+      'INVALID_TOKEN',
+      'Token is invalid or expired',
+      'UNAUTHORIZED'
+    );
+    
+    vi.mocked(mockAuthUseCase.validateToken).mockResolvedValue({
+      success: false,
+      error
+    });
+
+    await authenticate(mockRequest as FastifyRequest, mockReply as FastifyReply);
+
+    expect(mockReply.code).toHaveBeenCalledWith(401);
+    expect(mockReply.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: expect.stringContaining('/errors/invalid-token'),
+        title: 'Token is invalid or expired',
+        status: 401,
+      })
+    );
+    expect(mockRequest.log.warn).toHaveBeenCalled();
+  });
+
+  it('should return 500 when unexpected error occurs', async () => {
+    mockRequest.headers = {
+      authorization: 'Bearer valid-token',
+    };
+    
+    vi.mocked(mockAuthUseCase.validateToken).mockRejectedValue(
+      new Error('Unexpected error')
+    );
+
+    await authenticate(mockRequest as FastifyRequest, mockReply as FastifyReply);
+
+    expect(mockReply.code).toHaveBeenCalledWith(500);
+    expect(mockReply.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: expect.stringContaining('/errors/auth-error'),
+        title: 'An error occurred during authentication',
+        status: 500,
+      })
+    );
+    expect(mockRequest.log.error).toHaveBeenCalled();
+  });
+
+  it('should handle non-string authorization header', async () => {
+    mockRequest.headers = {
+      authorization: ['Bearer token1', 'Bearer token2'] as any,
+    };
+
+    await authenticate(mockRequest as FastifyRequest, mockReply as FastifyReply);
+
+    expect(mockReply.code).toHaveBeenCalledWith(401);
+    expect(mockReply.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: expect.stringContaining('/errors/missing-auth-header'),
+        title: 'Missing or invalid authorization header',
+        status: 401,
+      })
+    );
+  });
+});

--- a/packages/backend/src/presentation/middleware/authenticate.ts
+++ b/packages/backend/src/presentation/middleware/authenticate.ts
@@ -1,0 +1,126 @@
+import { FastifyRequest, FastifyReply } from 'fastify';
+import { container } from 'tsyringe';
+import { AuthenticationUseCase } from '@/application/use-cases/authentication.use-case';
+import { toProblemDetails } from '@/presentation/errors/error-mapper';
+import { DI_TOKENS } from '@/infrastructure/di/tokens';
+
+/**
+ * 認証ミドルウェア
+ * Authorizationヘッダーからトークンを抽出し、検証する
+ */
+export async function authenticate(
+  request: FastifyRequest,
+  reply: FastifyReply
+): Promise<void> {
+  try {
+    // Authorizationヘッダーの取得
+    const authHeader = request.headers.authorization;
+    
+    if (!authHeader || typeof authHeader !== 'string') {
+      const problemDetails = toProblemDetails(
+        {
+          code: 'MISSING_AUTH_HEADER',
+          message: 'Missing or invalid authorization header',
+          type: 'UNAUTHORIZED',
+        },
+        request.url
+      );
+      
+      reply
+        .code(401)
+        .header('content-type', 'application/problem+json')
+        .header('www-authenticate', 'Bearer')
+        .send(problemDetails);
+      return;
+    }
+
+    // Bearer トークンの抽出
+    const bearerMatch = authHeader.match(/^Bearer\s+(.+)$/);
+    if (!bearerMatch || !bearerMatch[1]) {
+      const problemDetails = toProblemDetails(
+        {
+          code: 'INVALID_AUTH_FORMAT',
+          message: 'Authorization header must use Bearer scheme',
+          type: 'UNAUTHORIZED',
+        },
+        request.url
+      );
+      
+      reply
+        .code(401)
+        .header('content-type', 'application/problem+json')
+        .header('www-authenticate', 'Bearer')
+        .send(problemDetails);
+      return;
+    }
+
+    const token = bearerMatch[1];
+    
+    // トークンの検証
+    const authUseCase = container.resolve<AuthenticationUseCase>(DI_TOKENS.AuthenticationUseCase);
+    const result = await authUseCase.validateToken(token);
+
+    if (!result.success) {
+      const problemDetails = toProblemDetails(
+        result.error,
+        request.url
+      );
+      
+      request.log.warn({
+        error: result.error?.code,
+        message: result.error?.message,
+      }, 'Authentication failed');
+      
+      reply
+        .code(401)
+        .header('content-type', 'application/problem+json')
+        .header('www-authenticate', 'Bearer')
+        .send(problemDetails);
+      return;
+    }
+
+    // 認証成功 - ユーザー情報をリクエストに追加
+    request.user = result.data.user;
+    request.authenticatedUser = result.data.user;
+    
+    request.log.info({
+      userId: result.data.user.userId.value,
+      tier: result.data.user.tier.level,
+    }, 'User authenticated successfully');
+    
+  } catch (error) {
+    request.log.error({
+      error: error instanceof Error ? error.message : 'Unknown error',
+      stack: error instanceof Error ? error.stack : undefined,
+    }, 'Unexpected error during authentication');
+
+    const problemDetails = toProblemDetails(
+      {
+        code: 'AUTH_ERROR',
+        message: 'An error occurred during authentication',
+        type: 'INTERNAL',
+      },
+      request.url
+    );
+
+    reply
+      .code(500)
+      .header('content-type', 'application/problem+json')
+      .send(problemDetails);
+  }
+}
+
+/**
+ * 認証デコレータプラグイン
+ * Fastifyインスタンスに認証メソッドを追加
+ */
+export function registerAuthDecorator(fastify: any): void {
+  fastify.decorate('authenticate', authenticate);
+}
+
+// Fastifyの型定義を拡張
+declare module 'fastify' {
+  interface FastifyInstance {
+    authenticate: typeof authenticate;
+  }
+}

--- a/packages/backend/src/presentation/routes/auth/__tests__/logout.route.test.ts
+++ b/packages/backend/src/presentation/routes/auth/__tests__/logout.route.test.ts
@@ -1,0 +1,282 @@
+import 'reflect-metadata';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fastify, { FastifyInstance } from 'fastify';
+import { container } from 'tsyringe';
+import { setupTestDI } from '../../../../infrastructure/di';
+import logoutRoute from '../logout.route';
+import { AuthenticationUseCase } from '../../../../application/use-cases/authentication.use-case';
+import { ApplicationError } from '../../../../application/errors/application-error';
+import { DI_TOKENS } from '../../../../infrastructure/di/tokens';
+import type { Result } from '../../../../application/errors/result';
+import { AuthenticatedUser } from '../../../../domain/auth/value-objects/authenticated-user';
+import { UserId } from '../../../../domain/auth/value-objects/user-id';
+import { UserTier } from '../../../../domain/auth/value-objects/user-tier';
+import { registerAuthDecorator } from '../../../middleware/authenticate';
+
+describe('Logout Route', () => {
+  let app: FastifyInstance;
+  let mockAuthUseCase: Partial<AuthenticationUseCase>;
+  
+  function createMockAuthenticatedUser(userId = 'test-user-123'): AuthenticatedUser {
+    return new AuthenticatedUser(
+      new UserId(userId),
+      new UserTier('tier1')
+    );
+  }
+
+  beforeEach(async () => {
+    setupTestDI();
+    
+    // Mock AuthenticationUseCase
+    mockAuthUseCase = {
+      validateToken: vi.fn(),
+      signOut: vi.fn(),
+    };
+    
+    container.register(DI_TOKENS.AuthenticationUseCase, {
+      useValue: mockAuthUseCase,
+    });
+
+    app = fastify({ logger: false });
+    
+    // Register authentication decorator
+    registerAuthDecorator(app);
+    
+    // Register error handler to properly format validation errors
+    await app.register(import('../../../plugins/error-handler'));
+    
+    await app.register(logoutRoute);
+  });
+
+  afterEach(async () => {
+    await app.close();
+    vi.clearAllMocks();
+  });
+
+  describe('POST /logout', () => {
+    it('should logout successfully with valid token', async () => {
+      const mockUser = createMockAuthenticatedUser();
+      
+      // Mock successful token validation
+      vi.mocked(mockAuthUseCase.validateToken).mockResolvedValue({
+        success: true,
+        data: {
+          user: mockUser,
+          tokenId: 'token-123'
+        }
+      });
+      
+      // Mock successful logout
+      vi.mocked(mockAuthUseCase.signOut).mockResolvedValue({
+        success: true,
+        data: undefined
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/logout',
+        headers: {
+          authorization: 'Bearer valid-token',
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(response.headers['content-type']).toContain('application/json');
+      expect(response.headers['clear-site-data']).toBe('"storage"');
+      
+      const body = JSON.parse(response.body);
+      expect(body).toMatchObject({
+        message: 'Logout successful',
+        timestamp: expect.any(String),
+      });
+
+      expect(mockAuthUseCase.validateToken).toHaveBeenCalledWith('valid-token');
+      expect(mockAuthUseCase.signOut).toHaveBeenCalledWith('test-user-123');
+    });
+
+    it('should return 401 when authorization header is missing', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/logout',
+      });
+
+      expect(response.statusCode).toBe(401);
+      expect(response.headers['content-type']).toContain('application/problem+json');
+      expect(response.headers['www-authenticate']).toBe('Bearer');
+      
+      const body = JSON.parse(response.body);
+      expect(body).toMatchObject({
+        type: expect.stringContaining('/errors/missing-auth-header'),
+        title: 'Missing or invalid authorization header',
+        status: 401,
+        instance: '/logout',
+      });
+
+      expect(mockAuthUseCase.validateToken).not.toHaveBeenCalled();
+      expect(mockAuthUseCase.signOut).not.toHaveBeenCalled();
+    });
+
+    it('should return 401 when authorization header format is invalid', async () => {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/logout',
+        headers: {
+          authorization: 'InvalidFormat token',
+        },
+      });
+
+      expect(response.statusCode).toBe(401);
+      expect(response.headers['content-type']).toContain('application/problem+json');
+      expect(response.headers['www-authenticate']).toBe('Bearer');
+      
+      const body = JSON.parse(response.body);
+      expect(body).toMatchObject({
+        type: expect.stringContaining('/errors/invalid-auth-format'),
+        title: 'Authorization header must use Bearer scheme',
+        status: 401,
+      });
+    });
+
+    it('should return 401 when token is invalid', async () => {
+      const error = new ApplicationError(
+        'INVALID_TOKEN',
+        'Token is invalid or expired',
+        'UNAUTHORIZED'
+      );
+
+      vi.mocked(mockAuthUseCase.validateToken).mockResolvedValue({
+        success: false,
+        error
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/logout',
+        headers: {
+          authorization: 'Bearer invalid-token',
+        },
+      });
+
+      expect(response.statusCode).toBe(401);
+      expect(response.headers['content-type']).toContain('application/problem+json');
+      
+      const body = JSON.parse(response.body);
+      expect(body).toMatchObject({
+        type: expect.stringContaining('/errors/invalid-token'),
+        title: 'Token is invalid or expired',
+        status: 401,
+      });
+
+      expect(mockAuthUseCase.signOut).not.toHaveBeenCalled();
+    });
+
+    it('should return 503 when logout fails due to external service', async () => {
+      const mockUser = createMockAuthenticatedUser();
+      
+      vi.mocked(mockAuthUseCase.validateToken).mockResolvedValue({
+        success: true,
+        data: {
+          user: mockUser,
+          tokenId: 'token-123'
+        }
+      });
+
+      const error = new ApplicationError(
+        'LOGOUT_ERROR',
+        'Failed to invalidate session',
+        'EXTERNAL_SERVICE'
+      );
+
+      vi.mocked(mockAuthUseCase.signOut).mockResolvedValue({
+        success: false,
+        error
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/logout',
+        headers: {
+          authorization: 'Bearer valid-token',
+        },
+      });
+
+      expect(response.statusCode).toBe(503);
+      expect(response.headers['content-type']).toContain('application/problem+json');
+      
+      const body = JSON.parse(response.body);
+      expect(body).toMatchObject({
+        type: expect.stringContaining('/errors/logout-error'),
+        title: 'Failed to invalidate session',
+        status: 503,
+      });
+    });
+
+    it('should return 500 when logout fails due to internal error', async () => {
+      const mockUser = createMockAuthenticatedUser();
+      
+      vi.mocked(mockAuthUseCase.validateToken).mockResolvedValue({
+        success: true,
+        data: {
+          user: mockUser,
+          tokenId: 'token-123'
+        }
+      });
+
+      const error = new ApplicationError(
+        'INTERNAL_ERROR',
+        'Internal server error',
+        'INTERNAL'
+      );
+
+      vi.mocked(mockAuthUseCase.signOut).mockResolvedValue({
+        success: false,
+        error
+      });
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/logout',
+        headers: {
+          authorization: 'Bearer valid-token',
+        },
+      });
+
+      expect(response.statusCode).toBe(500);
+      expect(response.headers['content-type']).toContain('application/problem+json');
+    });
+
+    it('should return 503 when unexpected error occurs', async () => {
+      const mockUser = createMockAuthenticatedUser();
+      
+      vi.mocked(mockAuthUseCase.validateToken).mockResolvedValue({
+        success: true,
+        data: {
+          user: mockUser,
+          tokenId: 'token-123'
+        }
+      });
+
+      vi.mocked(mockAuthUseCase.signOut).mockRejectedValue(
+        new Error('Unexpected error')
+      );
+
+      const response = await app.inject({
+        method: 'POST',
+        url: '/logout',
+        headers: {
+          authorization: 'Bearer valid-token',
+        },
+      });
+
+      expect(response.statusCode).toBe(503);
+      expect(response.headers['content-type']).toContain('application/problem+json');
+      
+      const body = JSON.parse(response.body);
+      expect(body).toMatchObject({
+        type: expect.stringContaining('/errors/logout-error'),
+        title: 'An error occurred during logout',
+        status: 503,
+      });
+    });
+  });
+});

--- a/packages/backend/src/presentation/routes/auth/index.ts
+++ b/packages/backend/src/presentation/routes/auth/index.ts
@@ -1,5 +1,6 @@
 import { FastifyPluginAsync } from 'fastify';
 import refreshRoute from './refresh.route';
+import logoutRoute from './logout.route';
 
 /**
  * 認証関連のルートを登録するプラグイン
@@ -8,8 +9,10 @@ const authRoutes: FastifyPluginAsync = async (fastify) => {
   // トークンリフレッシュエンドポイント
   await fastify.register(refreshRoute);
   
+  // ログアウトエンドポイント
+  await fastify.register(logoutRoute);
+  
   // TODO: 後続タスクで以下のルートを追加
-  // - /auth/logout (task-0018)
   // - その他の認証関連エンドポイント
 };
 

--- a/packages/backend/src/presentation/routes/auth/logout.route.ts
+++ b/packages/backend/src/presentation/routes/auth/logout.route.ts
@@ -1,0 +1,151 @@
+import { FastifyPluginAsync } from 'fastify';
+import { Static, Type } from '@sinclair/typebox';
+import { container } from 'tsyringe';
+import { AuthenticationUseCase } from '@/application/use-cases/authentication.use-case';
+import { toProblemDetails } from '@/presentation/errors/error-mapper';
+import { DI_TOKENS } from '@/infrastructure/di/tokens';
+
+// レスポンススキーマ
+const LogoutResponse = Type.Object({
+  message: Type.String({
+    description: 'Success message',
+  }),
+  timestamp: Type.String({
+    description: 'Logout timestamp in ISO 8601 format',
+  }),
+});
+
+// エラーレスポンスのスキーマ
+const ErrorResponse = Type.Object({
+  type: Type.String(),
+  title: Type.String(),
+  status: Type.Number(),
+  detail: Type.Optional(Type.String()),
+  instance: Type.String(),
+});
+
+type LogoutResponseType = Static<typeof LogoutResponse>;
+
+const logoutRoute: FastifyPluginAsync = async (fastify) => {
+  const authUseCase = container.resolve<AuthenticationUseCase>(DI_TOKENS.AuthenticationUseCase);
+
+  fastify.post<{
+    Reply: LogoutResponseType | Static<typeof ErrorResponse>;
+  }>(
+    '/logout',
+    {
+      schema: {
+        description: 'Logout the authenticated user',
+        tags: ['Authentication'],
+        response: {
+          200: {
+            description: 'Logout successful',
+            ...LogoutResponse,
+          },
+          401: {
+            description: 'Unauthorized - Invalid or missing token',
+            ...ErrorResponse,
+          },
+          503: {
+            description: 'Service unavailable',
+            ...ErrorResponse,
+          },
+        },
+        security: [
+          {
+            bearerAuth: [],
+          },
+        ],
+      },
+      // 認証が必須
+      preHandler: fastify.authenticate,
+    },
+    async (request, reply) => {
+      try {
+        // 認証済みユーザーの取得（preHandlerで保証される）
+        const authenticatedUser = request.user;
+        
+        if (!authenticatedUser) {
+          const problemDetails = toProblemDetails(
+            {
+              code: 'USER_NOT_AUTHENTICATED',
+              message: 'User not authenticated',
+              type: 'UNAUTHORIZED',
+            },
+            request.url
+          );
+          
+          return reply
+            .code(401)
+            .header('content-type', 'application/problem+json')
+            .send(problemDetails);
+        }
+
+        request.log.info({
+          userId: authenticatedUser.userId.value,
+          tier: authenticatedUser.tier.level,
+        }, 'Logout request received');
+
+        // ログアウト処理
+        const result = await authUseCase.signOut(authenticatedUser.userId.value);
+
+        if (!result.success) {
+          const problemDetails = toProblemDetails(
+            result.error,
+            request.url
+          );
+          
+          request.log.error({
+            userId: authenticatedUser.userId.value,
+            error: result.error?.code,
+          }, 'Logout failed');
+
+          // エラーの種類によってステータスコードを決定
+          const statusCode = result.error?.type === 'EXTERNAL_SERVICE' ? 503 : 500;
+          
+          return reply
+            .code(statusCode)
+            .header('content-type', 'application/problem+json')
+            .send(problemDetails);
+        }
+
+        request.log.info({
+          userId: authenticatedUser.userId.value,
+        }, 'User logged out successfully');
+
+        // 成功レスポンス
+        const response: LogoutResponseType = {
+          message: 'Logout successful',
+          timestamp: new Date().toISOString(),
+        };
+
+        // クライアントへのヒント：トークンを削除するよう指示
+        reply.header('Clear-Site-Data', '"storage"');
+        
+        return reply.send(response);
+      } catch (error) {
+        request.log.error({
+          error: error instanceof Error ? error.message : 'Unknown error',
+          stack: error instanceof Error ? error.stack : undefined,
+          userId: request.user?.userId.value,
+        }, 'Unexpected error during logout');
+
+        const problemDetails = toProblemDetails(
+          {
+            code: 'LOGOUT_ERROR',
+            message: 'An error occurred during logout',
+            type: 'EXTERNAL_SERVICE',
+          },
+          request.url
+        );
+
+        return reply
+          .code(503)
+          .header('content-type', 'application/problem+json')
+          .send(problemDetails);
+      }
+    }
+  );
+};
+
+export default logoutRoute;

--- a/packages/backend/src/server.ts
+++ b/packages/backend/src/server.ts
@@ -26,6 +26,10 @@ await server.register(import('./presentation/plugins/security-headers'));
 await server.register(import('./presentation/plugins/path-validation'));
 await server.register(import('./presentation/plugins/error-handler'));
 
+// 認証ミドルウェアの登録
+import { registerAuthDecorator } from './presentation/middleware/authenticate';
+registerAuthDecorator(server);
+
 // APIルートの登録
 await server.register(import('./presentation/routes'), { prefix: '/api/v1' });
 


### PR DESCRIPTION
## Summary
- Implemented authentication middleware for protecting endpoints
- Implemented POST /api/v1/auth/logout endpoint
- Added comprehensive tests for both components

## Implementation Details
- Created `authenticate.ts` middleware that validates JWT tokens from Authorization header
- Middleware extracts authenticated user and adds it to the request object
- Created `logout.route.ts` with proper schema validation and error handling
- Logout endpoint calls AuthenticationUseCase.signOut and returns success message
- Added Clear-Site-Data header to hint clients to clear local storage

## Authentication Middleware Features
- Validates Bearer token format
- Handles missing/invalid authorization headers
- Returns RFC 7807 Problem Details for errors
- Sets WWW-Authenticate header on 401 responses
- Logs authentication success/failure for monitoring

## Test Plan
- [x] All middleware tests pass (6 tests)
- [x] All logout route tests pass (7 tests)
- [x] Valid token allows logout
- [x] Missing authorization header returns 401
- [x] Invalid token format returns 401
- [x] Invalid token returns 401
- [x] External service errors return 503
- [x] Unexpected errors handled gracefully

## Related
- Implements task-0018 from the implementation plan
- Uses AuthenticationUseCase from previous tasks
- Follows established error handling patterns

🤖 Generated with [Claude Code](https://claude.ai/code)