### PR TITLE
feat: UserRepositoryの実装（Supabase Auth連携）

### DIFF
--- a/packages/backend/src/domain/auth/entities/user.ts
+++ b/packages/backend/src/domain/auth/entities/user.ts
@@ -1,0 +1,165 @@
+import { Entity, UniqueEntityId } from '@/domain/shared/entity';
+import { UserId } from '../value-objects/user-id';
+import { Email } from '../value-objects/email';
+import { UserTier } from '../value-objects/user-tier';
+import { Result } from '@/domain/shared/result';
+import { DomainError, ErrorType } from '@/domain/errors/domain-error';
+
+export interface UserProps {
+  email: Email;
+  tier: UserTier;
+  createdAt: Date;
+  updatedAt: Date;
+  lastAuthenticatedAt?: Date;
+  emailVerified: boolean;
+  metadata?: Record<string, any>;
+}
+
+/**
+ * ユーザーエンティティ
+ * 
+ * アプリケーションのユーザーを表現するドメインエンティティ
+ */
+export class User extends Entity<UserProps> {
+  private constructor(props: UserProps, id?: UniqueEntityId) {
+    super(props, id);
+  }
+  get id(): UserId {
+    // UniqueEntityIdからUserIdを作成
+    return UserId.create(this._id.value).getValue();
+  }
+
+  get email(): Email {
+    return this.props.email;
+  }
+
+  get tier(): UserTier {
+    return this.props.tier;
+  }
+
+  get createdAt(): Date {
+    return this.props.createdAt;
+  }
+
+  get updatedAt(): Date {
+    return this.props.updatedAt;
+  }
+
+  get lastAuthenticatedAt(): Date | undefined {
+    return this.props.lastAuthenticatedAt;
+  }
+
+  get emailVerified(): boolean {
+    return this.props.emailVerified;
+  }
+
+  get metadata(): Record<string, any> | undefined {
+    return this.props.metadata;
+  }
+
+  /**
+   * ユーザーの作成
+   */
+  public static create(props: {
+    id: UserId;
+    email: Email;
+    tier: UserTier;
+    emailVerified?: boolean;
+    metadata?: Record<string, any>;
+  }): Result<User> {
+    const now = new Date();
+    
+    const user = new User({
+      email: props.email,
+      tier: props.tier,
+      createdAt: now,
+      updatedAt: now,
+      emailVerified: props.emailVerified ?? false,
+      metadata: props.metadata,
+    }, new UniqueEntityId(props.id.value));
+
+    return Result.ok(user);
+  }
+
+  /**
+   * 既存データからの再構築
+   */
+  public static reconstruct(props: UserProps & { id: UserId }): User {
+    return new User({
+      email: props.email,
+      tier: props.tier,
+      createdAt: props.createdAt,
+      updatedAt: props.updatedAt,
+      lastAuthenticatedAt: props.lastAuthenticatedAt,
+      emailVerified: props.emailVerified,
+      metadata: props.metadata,
+    }, new UniqueEntityId(props.id.value));
+  }
+
+  /**
+   * メールアドレスの更新
+   */
+  public updateEmail(email: Email): Result<void> {
+    if (this.props.email.equals(email)) {
+      return Result.fail(
+        new DomainError(
+          'EMAIL_NOT_CHANGED',
+          'The email address is the same as the current one',
+          ErrorType.VALIDATION
+        )
+      );
+    }
+
+    this.props.email = email;
+    this.props.emailVerified = false; // メール変更時は再検証が必要
+    this.props.updatedAt = new Date();
+    
+    return Result.ok();
+  }
+
+  /**
+   * ティアの更新
+   */
+  public updateTier(tier: UserTier): Result<void> {
+    if (this.props.tier.equals(tier)) {
+      return Result.fail(
+        new DomainError(
+          'TIER_NOT_CHANGED',
+          'The tier is the same as the current one',
+          ErrorType.VALIDATION
+        )
+      );
+    }
+
+    this.props.tier = tier;
+    this.props.updatedAt = new Date();
+    
+    return Result.ok();
+  }
+
+  /**
+   * メール検証済みに更新
+   */
+  public verifyEmail(): void {
+    this.props.emailVerified = true;
+    this.props.updatedAt = new Date();
+  }
+
+  /**
+   * 最終認証日時の更新
+   */
+  public updateLastAuthenticatedAt(): void {
+    this.props.lastAuthenticatedAt = new Date();
+    this.props.updatedAt = new Date();
+  }
+
+  /**
+   * メタデータの更新
+   */
+  public updateMetadata(metadata: Record<string, any>): void {
+    this.props.metadata = { ...this.props.metadata, ...metadata };
+    this.props.updatedAt = new Date();
+  }
+
+  // equals メソッドは基底クラスのEntity から継承される
+}

--- a/packages/backend/src/domain/auth/interfaces/user-repository.interface.ts
+++ b/packages/backend/src/domain/auth/interfaces/user-repository.interface.ts
@@ -1,0 +1,36 @@
+import { Result } from '@/domain/shared/result';
+import { User } from '../entities/user';
+import { UserId } from '../value-objects/user-id';
+import { Email } from '../value-objects/email';
+
+/**
+ * ユーザーリポジトリインターフェース
+ * 
+ * ユーザー情報の永続化と取得を担当する
+ */
+export interface IUserRepository {
+  /**
+   * IDによるユーザー検索
+   */
+  findById(id: UserId): Promise<Result<User | null>>;
+
+  /**
+   * メールアドレスによるユーザー検索
+   */
+  findByEmail(email: Email): Promise<Result<User | null>>;
+
+  /**
+   * ユーザーの保存（新規作成）
+   */
+  save(user: User): Promise<Result<void>>;
+
+  /**
+   * ユーザーの更新
+   */
+  update(user: User): Promise<Result<void>>;
+
+  /**
+   * ユーザーの削除
+   */
+  delete(id: UserId): Promise<Result<void>>;
+}

--- a/packages/backend/src/domain/auth/value-objects/email.ts
+++ b/packages/backend/src/domain/auth/value-objects/email.ts
@@ -1,0 +1,108 @@
+import { ValueObject } from '@/domain/shared/value-object';
+import { Result } from '@/domain/shared/result';
+import { DomainError, ErrorType } from '@/domain/errors/domain-error';
+
+interface EmailProps {
+  value: string;
+}
+
+/**
+ * メールアドレスバリューオブジェクト
+ */
+export class Email extends ValueObject<EmailProps> {
+  private static readonly EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  private static readonly MAX_LENGTH = 255;
+
+  get value(): string {
+    return this.props.value;
+  }
+
+  /**
+   * メールアドレスの作成
+   */
+  public static create(email: string): Result<Email> {
+    // null/undefined チェック
+    if (email === null || email === undefined) {
+      return Result.fail(
+        new DomainError(
+          'EMAIL_REQUIRED',
+          'Email is required',
+          ErrorType.VALIDATION
+        )
+      );
+    }
+
+    // 文字列型チェック
+    if (typeof email !== 'string') {
+      return Result.fail(
+        new DomainError(
+          'EMAIL_INVALID_TYPE',
+          'Email must be a string',
+          ErrorType.VALIDATION
+        )
+      );
+    }
+
+    // トリミング
+    const trimmedEmail = email.trim();
+
+    // 空文字チェック
+    if (trimmedEmail.length === 0) {
+      return Result.fail(
+        new DomainError(
+          'EMAIL_EMPTY',
+          'Email cannot be empty',
+          ErrorType.VALIDATION
+        )
+      );
+    }
+
+    // 長さチェック
+    if (trimmedEmail.length > Email.MAX_LENGTH) {
+      return Result.fail(
+        new DomainError(
+          'EMAIL_TOO_LONG',
+          `Email must be ${Email.MAX_LENGTH} characters or less`,
+          ErrorType.VALIDATION
+        )
+      );
+    }
+
+    // フォーマットチェック
+    if (!Email.EMAIL_REGEX.test(trimmedEmail)) {
+      return Result.fail(
+        new DomainError(
+          'EMAIL_INVALID_FORMAT',
+          'Email format is invalid',
+          ErrorType.VALIDATION
+        )
+      );
+    }
+
+    // 小文字に正規化
+    const normalizedEmail = trimmedEmail.toLowerCase();
+
+    return Result.ok(new Email({ value: normalizedEmail }));
+  }
+
+  /**
+   * ドメイン部分の取得
+   */
+  public getDomain(): string {
+    return this.props.value.split('@')[1];
+  }
+
+  /**
+   * ローカル部分の取得
+   */
+  public getLocalPart(): string {
+    return this.props.value.split('@')[0];
+  }
+
+  /**
+   * 文字列表現
+   */
+  public toString(): string {
+    return this.props.value;
+  }
+}

--- a/packages/backend/src/infrastructure/auth/__mocks__/supabase-auth.adapter.ts
+++ b/packages/backend/src/infrastructure/auth/__mocks__/supabase-auth.adapter.ts
@@ -5,6 +5,23 @@ export class MockSupabaseAuthAdapter implements IAuthAdapter {
   private mockTokens = new Map<string, TokenPayload>();
   private mockSessions = new Map<string, Session>();
   private signedOutUsers = new Set<string>();
+  private users: Map<string, any> = new Map();
+  private usersByEmail: Map<string, any> = new Map();
+
+  constructor() {
+    // デフォルトのテストユーザーを追加
+    const testUser = {
+      id: '123e4567-e89b-12d3-a456-426614174000',
+      email: 'test@example.com',
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      email_confirmed_at: new Date().toISOString(),
+      app_metadata: { tier: 'tier1' },
+      user_metadata: {},
+    };
+    this.users.set(testUser.id, testUser);
+    this.usersByEmail.set(testUser.email, testUser);
+  }
 
   async verifyToken(token: string): Promise<TokenPayload | null> {
     return this.mockTokens.get(token) || null;
@@ -24,6 +41,78 @@ export class MockSupabaseAuthAdapter implements IAuthAdapter {
     }
   }
 
+  async getUserById(userId: string): Promise<any | null> {
+    return this.users.get(userId) || null;
+  }
+
+  async getUserByEmail(email: string): Promise<any | null> {
+    return this.usersByEmail.get(email) || null;
+  }
+
+  async createUser(userData: {
+    id?: string;
+    email: string;
+    email_confirmed?: boolean;
+    app_metadata?: Record<string, any>;
+    user_metadata?: Record<string, any>;
+  }): Promise<any | null> {
+    const user = {
+      id: userData.id || `test-user-${Date.now()}`,
+      email: userData.email,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      email_confirmed_at: userData.email_confirmed ? new Date().toISOString() : null,
+      app_metadata: userData.app_metadata || {},
+      user_metadata: userData.user_metadata || {},
+    };
+    
+    this.users.set(user.id, user);
+    this.usersByEmail.set(user.email, user);
+    
+    return user;
+  }
+
+  async updateUser(userId: string, updates: {
+    email?: string;
+    email_confirmed?: boolean;
+    app_metadata?: Record<string, any>;
+    user_metadata?: Record<string, any>;
+  }): Promise<any | null> {
+    const user = this.users.get(userId);
+    if (!user) return null;
+    
+    // 古いメールアドレスのマッピングを削除
+    if (updates.email && updates.email !== user.email) {
+      this.usersByEmail.delete(user.email);
+    }
+    
+    // ユーザー情報を更新
+    if (updates.email !== undefined) user.email = updates.email;
+    if (updates.email_confirmed !== undefined) {
+      user.email_confirmed_at = updates.email_confirmed ? new Date().toISOString() : null;
+    }
+    if (updates.app_metadata !== undefined) user.app_metadata = updates.app_metadata;
+    if (updates.user_metadata !== undefined) user.user_metadata = updates.user_metadata;
+    user.updated_at = new Date().toISOString();
+    
+    // 新しいメールアドレスのマッピングを追加
+    if (updates.email) {
+      this.usersByEmail.set(user.email, user);
+    }
+    
+    return user;
+  }
+
+  async deleteUser(userId: string): Promise<boolean> {
+    const user = this.users.get(userId);
+    if (!user) return false;
+    
+    this.users.delete(userId);
+    this.usersByEmail.delete(user.email);
+    
+    return true;
+  }
+
   // テスト用ヘルパーメソッド
   setMockToken(token: string, payload: TokenPayload): void {
     this.mockTokens.set(token, payload);
@@ -37,9 +126,29 @@ export class MockSupabaseAuthAdapter implements IAuthAdapter {
     return this.signedOutUsers.has(userId);
   }
 
+  setMockUser(user: any): void {
+    this.users.set(user.id, user);
+    this.usersByEmail.set(user.email, user);
+  }
+
   reset(): void {
     this.mockTokens.clear();
     this.mockSessions.clear();
     this.signedOutUsers.clear();
+    this.users.clear();
+    this.usersByEmail.clear();
+    
+    // デフォルトのテストユーザーを再追加
+    const testUser = {
+      id: '123e4567-e89b-12d3-a456-426614174000',
+      email: 'test@example.com',
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      email_confirmed_at: new Date().toISOString(),
+      app_metadata: { tier: 'tier1' },
+      user_metadata: {},
+    };
+    this.users.set(testUser.id, testUser);
+    this.usersByEmail.set(testUser.email, testUser);
   }
 }

--- a/packages/backend/src/infrastructure/auth/interfaces/auth-adapter.interface.ts
+++ b/packages/backend/src/infrastructure/auth/interfaces/auth-adapter.interface.ts
@@ -4,6 +4,24 @@ export interface IAuthAdapter {
   verifyToken(token: string): Promise<TokenPayload | null>;
   refreshAccessToken(refreshToken: string): Promise<Session | null>;
   signOut(userId: string): Promise<void>;
+  
+  // User management methods
+  getUserById(userId: string): Promise<any | null>;
+  getUserByEmail(email: string): Promise<any | null>;
+  createUser(userData: {
+    id?: string;
+    email: string;
+    email_confirmed?: boolean;
+    app_metadata?: Record<string, any>;
+    user_metadata?: Record<string, any>;
+  }): Promise<any | null>;
+  updateUser(userId: string, updates: {
+    email?: string;
+    email_confirmed?: boolean;
+    app_metadata?: Record<string, any>;
+    user_metadata?: Record<string, any>;
+  }): Promise<any | null>;
+  deleteUser(userId: string): Promise<boolean>;
 }
 
 export interface Session {

--- a/packages/backend/src/infrastructure/di/container.ts
+++ b/packages/backend/src/infrastructure/di/container.ts
@@ -132,15 +132,11 @@ export function setupTestDI(): DependencyContainer {
     },
   });
   
-  // テスト用にUserRepositoryのモックを登録（auth.plugin.tsで必要）
-  container.register(DI_TOKENS.UserRepository, {
-    useValue: {
-      findById: () => Promise.resolve(Result.ok(null)),
-      findByEmail: () => Promise.resolve(Result.ok(null)),
-      save: () => Promise.resolve(Result.ok()),
-      update: () => Promise.resolve(Result.ok()),
-      delete: () => Promise.resolve(Result.ok()),
-    },
+  // テスト用にSupabaseUserRepositoryを登録
+  import('../repositories/auth/supabase-user.repository').then(module => {
+    container.register(DI_TOKENS.UserRepository, {
+      useClass: module.SupabaseUserRepository,
+    });
   });
   
   // テスト用にRateLimitLogRepositoryのモックを登録（必要な場合）
@@ -252,6 +248,13 @@ function registerInfrastructureServices(container: DependencyContainer): void {
   // JWTValidatorの登録
   container.register<IJWTValidator>(DI_TOKENS.JWTValidator, {
     useClass: JWTValidatorService,
+  });
+  
+  // UserRepositoryの登録
+  import('../repositories/auth/supabase-user.repository').then(module => {
+    container.register(DI_TOKENS.UserRepository, {
+      useClass: module.SupabaseUserRepository,
+    });
   });
   
   // Factoriesの登録

--- a/packages/backend/src/infrastructure/repositories/auth/__tests__/supabase-user.repository.test.ts
+++ b/packages/backend/src/infrastructure/repositories/auth/__tests__/supabase-user.repository.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { SupabaseUserRepository } from '../supabase-user.repository';
+import { MockSupabaseAuthAdapter } from '@/infrastructure/auth/__mocks__/supabase-auth.adapter';
+import { UserId } from '@/domain/auth/value-objects/user-id';
+import { Email } from '@/domain/auth/value-objects/email';
+import { UserTier } from '@/domain/auth/value-objects/user-tier';
+import { TierLevel } from '@/domain/auth/value-objects/tier-level';
+import { User } from '@/domain/auth/entities/user';
+import { createMockLogger } from '@/test/mocks/logger.mock';
+
+describe('SupabaseUserRepository', () => {
+  let repository: SupabaseUserRepository;
+  let mockAuthAdapter: MockSupabaseAuthAdapter;
+  let mockLogger: any;
+
+  beforeEach(() => {
+    mockAuthAdapter = new MockSupabaseAuthAdapter();
+    mockLogger = createMockLogger();
+    // デバッグログを表示するように設定
+    mockLogger.debug = vi.fn((obj, msg) => console.log('DEBUG:', msg, obj));
+    mockLogger.error = vi.fn((obj, msg) => console.error('ERROR:', msg, obj));
+    repository = new SupabaseUserRepository(mockAuthAdapter, mockLogger);
+  });
+
+  describe('findById', () => {
+    it('既存のユーザーを正常に取得できる', async () => {
+      const userId = '123e4567-e89b-12d3-a456-426614174000';
+      const userIdResult = UserId.create(userId);
+      if (!userIdResult.isSuccess) {
+        throw new Error(`Failed to create UserId: ${userIdResult.getError().message}`);
+      }
+      const userIdVO = userIdResult.getValue();
+
+      const result = await repository.findById(userIdVO);
+
+      if (!result.isSuccess) {
+        console.error('Repository error:', result.getError());
+      }
+
+      expect(result.isSuccess).toBe(true);
+      expect(result.getValue()).not.toBeNull();
+      expect(result.getValue()?.id.value).toBe(userId);
+      expect(result.getValue()?.email.value).toBe('test@example.com');
+      expect(result.getValue()?.tier.level).toBe(TierLevel.TIER1);
+    });
+
+    it('存在しないユーザーの場合nullを返す', async () => {
+      const userId = '550e8400-e29b-41d4-a716-446655440001'; // 存在しないがvalid UUID v4
+      const userIdResult = UserId.create(userId);
+      if (!userIdResult.isSuccess) {
+        throw new Error(`Failed to create UserId: ${userIdResult.getError().message}`);
+      }
+      const userIdVO = userIdResult.getValue();
+
+      const result = await repository.findById(userIdVO);
+
+      expect(result.isSuccess).toBe(true);
+      expect(result.getValue()).toBeNull();
+    });
+
+    it('エラーが発生した場合は失敗を返す', async () => {
+      const userId = '123e4567-e89b-12d3-a456-426614174000';
+      const userIdVO = UserId.create(userId).getValue();
+      
+      vi.spyOn(mockAuthAdapter, 'getUserById').mockRejectedValue(new Error('Database error'));
+
+      const result = await repository.findById(userIdVO);
+
+      expect(result.isFailure).toBe(true);
+      expect(result.getError().code).toBe('USER_REPOSITORY_ERROR');
+    });
+  });
+
+  describe('findByEmail', () => {
+    it('既存のユーザーをメールアドレスで取得できる', async () => {
+      const email = 'test@example.com';
+      const emailVO = Email.create(email).getValue();
+
+      const result = await repository.findByEmail(emailVO);
+
+      expect(result.isSuccess).toBe(true);
+      expect(result.getValue()).not.toBeNull();
+      expect(result.getValue()?.email.value).toBe(email);
+    });
+
+    it('存在しないメールアドレスの場合nullを返す', async () => {
+      const email = 'nonexistent@example.com';
+      const emailVO = Email.create(email).getValue();
+
+      const result = await repository.findByEmail(emailVO);
+
+      expect(result.isSuccess).toBe(true);
+      expect(result.getValue()).toBeNull();
+    });
+  });
+
+  describe('save', () => {
+    it('新しいユーザーを正常に保存できる', async () => {
+      const userIdResult = UserId.create('550e8400-e29b-41d4-a716-446655440000');
+      if (!userIdResult.isSuccess) {
+        throw new Error(`Failed to create UserId: ${userIdResult.getError().message}`);
+      }
+      const userId = userIdResult.getValue();
+      
+      const emailResult = Email.create('newuser@example.com');
+      if (!emailResult.isSuccess) {
+        throw new Error(`Failed to create Email: ${emailResult.getError().message}`);
+      }
+      const email = emailResult.getValue();
+      
+      const tierResult = UserTier.create(TierLevel.TIER1);
+      if (!tierResult.isSuccess) {
+        throw new Error(`Failed to create UserTier: ${tierResult.getError().message}`);
+      }
+      const tier = tierResult.getValue();
+      
+      const userResult = User.create({
+        id: userId,
+        email: email,
+        tier: tier,
+        emailVerified: true,
+      });
+      
+      const user = userResult.getValue();
+
+      const result = await repository.save(user);
+
+      expect(result.isSuccess).toBe(true);
+      
+      // モックで作成されたことを確認
+      const createdUser = await mockAuthAdapter.getUserById(user.id.value);
+      expect(createdUser).not.toBeNull();
+      expect(createdUser.email).toBe('newuser@example.com');
+    });
+
+    it('ユーザー作成に失敗した場合はエラーを返す', async () => {
+      vi.spyOn(mockAuthAdapter, 'createUser').mockResolvedValue(null);
+
+      const userIdResult = UserId.create('550e8400-e29b-41d4-a716-446655440000');
+      if (!userIdResult.isSuccess) {
+        throw new Error(`Failed to create UserId: ${userIdResult.getError().message}`);
+      }
+      const userId = userIdResult.getValue();
+      
+      const emailResult = Email.create('newuser@example.com');
+      if (!emailResult.isSuccess) {
+        throw new Error(`Failed to create Email: ${emailResult.getError().message}`);
+      }
+      const email = emailResult.getValue();
+      
+      const tierResult = UserTier.create(TierLevel.TIER1);
+      if (!tierResult.isSuccess) {
+        throw new Error(`Failed to create UserTier: ${tierResult.getError().message}`);
+      }
+      const tier = tierResult.getValue();
+      
+      const userResult = User.create({
+        id: userId,
+        email: email,
+        tier: tier,
+      });
+      
+      const user = userResult.getValue();
+
+      const result = await repository.save(user);
+
+      expect(result.isFailure).toBe(true);
+      expect(result.getError().code).toBe('USER_CREATION_FAILED');
+    });
+  });
+
+  describe('update', () => {
+    it('既存のユーザーを正常に更新できる', async () => {
+      // 既存のユーザーを取得
+      const userId = UserId.create('123e4567-e89b-12d3-a456-426614174000').getValue();
+      const findResult = await repository.findById(userId);
+      const existingUser = findResult.getValue()!;
+
+      // メールアドレスを更新
+      const newEmail = Email.create('updated@example.com').getValue();
+      existingUser.updateEmail(newEmail);
+
+      const result = await repository.update(existingUser);
+
+      expect(result.isSuccess).toBe(true);
+      
+      // モックで更新されたことを確認
+      const updatedUser = await mockAuthAdapter.getUserById(existingUser.id.value);
+      expect(updatedUser.email).toBe('updated@example.com');
+    });
+
+    it('ユーザー更新に失敗した場合はエラーを返す', async () => {
+      vi.spyOn(mockAuthAdapter, 'updateUser').mockResolvedValue(null);
+
+      const userId = UserId.create('123e4567-e89b-12d3-a456-426614174000').getValue();
+      const findResult = await repository.findById(userId);
+      const existingUser = findResult.getValue()!;
+
+      const result = await repository.update(existingUser);
+
+      expect(result.isFailure).toBe(true);
+      expect(result.getError().code).toBe('USER_UPDATE_FAILED');
+    });
+  });
+
+  describe('delete', () => {
+    it('既存のユーザーを正常に削除できる', async () => {
+      const userId = UserId.create('123e4567-e89b-12d3-a456-426614174000').getValue();
+
+      const result = await repository.delete(userId);
+
+      expect(result.isSuccess).toBe(true);
+      
+      // モックで削除されたことを確認
+      const deletedUser = await mockAuthAdapter.getUserById(userId.value);
+      expect(deletedUser).toBeNull();
+    });
+
+    it('ユーザー削除に失敗した場合はエラーを返す', async () => {
+      vi.spyOn(mockAuthAdapter, 'deleteUser').mockResolvedValue(false);
+
+      const userId = UserId.create('123e4567-e89b-12d3-a456-426614174000').getValue();
+
+      const result = await repository.delete(userId);
+
+      expect(result.isFailure).toBe(true);
+      expect(result.getError().code).toBe('USER_DELETION_FAILED');
+    });
+  });
+
+  describe('mapToDomainUser', () => {
+    it('Supabaseユーザーを正しくドメインモデルに変換できる', async () => {
+      const supabaseUser = {
+        id: '123e4567-e89b-12d3-a456-426614174000',
+        email: 'test@example.com',
+        created_at: '2024-01-01T00:00:00Z',
+        updated_at: '2024-01-02T00:00:00Z',
+        last_sign_in_at: '2024-01-03T00:00:00Z',
+        email_confirmed_at: '2024-01-01T00:00:00Z',
+        app_metadata: { tier: 'tier2' },
+        user_metadata: { foo: 'bar' },
+      };
+
+      mockAuthAdapter.setMockUser(supabaseUser);
+
+      const userId = UserId.create(supabaseUser.id).getValue();
+      const result = await repository.findById(userId);
+
+      const user = result.getValue()!;
+      expect(user.id.value).toBe(supabaseUser.id);
+      expect(user.email.value).toBe(supabaseUser.email);
+      expect(user.tier.level).toBe(TierLevel.TIER2);
+      expect(user.emailVerified).toBe(true);
+      expect(user.metadata).toEqual({ foo: 'bar' });
+      expect(user.lastAuthenticatedAt).toEqual(new Date('2024-01-03T00:00:00Z'));
+    });
+
+    it('デフォルト値を適切に処理できる', async () => {
+      const supabaseUser = {
+        id: '123e4567-e89b-12d3-a456-426614174000',
+        email: 'test@example.com',
+        created_at: '2024-01-01T00:00:00Z',
+        // updated_at, last_sign_in_at は未設定
+        email_confirmed_at: null, // 明示的にnullを設定
+        // app_metadata, user_metadata は未設定
+      };
+
+      mockAuthAdapter.setMockUser(supabaseUser);
+
+      const userId = UserId.create(supabaseUser.id).getValue();
+      const result = await repository.findById(userId);
+
+      const user = result.getValue()!;
+      expect(user.tier.level).toBe(TierLevel.TIER1); // デフォルトはTIER1
+      expect(user.emailVerified).toBe(false); // email_confirmed_at が undefined なのでfalse
+      expect(user.metadata).toEqual({}); // デフォルトは空オブジェクト
+      expect(user.lastAuthenticatedAt).toBeUndefined();
+    });
+  });
+});

--- a/packages/backend/src/infrastructure/repositories/auth/supabase-user.repository.ts
+++ b/packages/backend/src/infrastructure/repositories/auth/supabase-user.repository.ts
@@ -1,0 +1,323 @@
+import { injectable, inject } from 'tsyringe';
+import { IUserRepository } from '@/domain/auth/interfaces/user-repository.interface';
+import { User, UserProps } from '@/domain/auth/entities/user';
+import { UserId } from '@/domain/auth/value-objects/user-id';
+import { Email } from '@/domain/auth/value-objects/email';
+import { UserTier } from '@/domain/auth/value-objects/user-tier';
+import { TierLevel } from '@/domain/auth/value-objects/tier-level';
+import { Result } from '@/domain/shared/result';
+import { DomainError, ErrorType } from '@/domain/errors/domain-error';
+import { IAuthAdapter } from '@/infrastructure/auth/interfaces/auth-adapter.interface';
+import { Logger } from 'pino';
+import { DI_TOKENS } from '@/infrastructure/di/tokens';
+
+/**
+ * Supabaseユーザーリポジトリ実装
+ * 
+ * Supabase Authと連携してユーザー情報を管理する
+ */
+@injectable()
+export class SupabaseUserRepository implements IUserRepository {
+  constructor(
+    @inject(DI_TOKENS.AuthAdapter)
+    private readonly authAdapter: IAuthAdapter,
+    @inject(DI_TOKENS.Logger)
+    private readonly logger: Logger
+  ) {}
+
+  /**
+   * IDによるユーザー検索
+   */
+  async findById(id: UserId): Promise<Result<User | null>> {
+    try {
+      this.logger.debug({ userId: id.value }, 'Finding user by ID');
+
+      // Supabase Authからユーザー情報を取得
+      const supabaseUser = await this.authAdapter.getUserById(id.value);
+      
+      if (!supabaseUser) {
+        this.logger.debug({ userId: id.value }, 'User not found');
+        return Result.ok(null);
+      }
+
+      // Supabaseユーザーからドメインモデルへ変換
+      const user = await this.mapToDomainUser(supabaseUser);
+      
+      if (!user) {
+        return Result.fail(
+          new DomainError(
+            'USER_MAPPING_ERROR',
+            'Failed to map user data to domain model',
+            ErrorType.INTERNAL
+          )
+        );
+      }
+      
+      this.logger.debug({ userId: id.value }, 'User found successfully');
+      return Result.ok(user);
+
+    } catch (error) {
+      this.logger.error({
+        error: error instanceof Error ? error.message : 'Unknown error',
+        userId: id.value,
+      }, 'Error finding user by ID');
+
+      return Result.fail(
+        new DomainError(
+          'USER_REPOSITORY_ERROR',
+          'Failed to find user by ID',
+          ErrorType.INTERNAL
+        )
+      );
+    }
+  }
+
+  /**
+   * メールアドレスによるユーザー検索
+   */
+  async findByEmail(email: Email): Promise<Result<User | null>> {
+    try {
+      this.logger.debug({ email: email.value }, 'Finding user by email');
+
+      // Supabase Authからユーザー情報を取得
+      const supabaseUser = await this.authAdapter.getUserByEmail(email.value);
+      
+      if (!supabaseUser) {
+        this.logger.debug({ email: email.value }, 'User not found');
+        return Result.ok(null);
+      }
+
+      // Supabaseユーザーからドメインモデルへ変換
+      const user = await this.mapToDomainUser(supabaseUser);
+      
+      if (!user) {
+        return Result.fail(
+          new DomainError(
+            'USER_MAPPING_ERROR',
+            'Failed to map user data to domain model',
+            ErrorType.INTERNAL
+          )
+        );
+      }
+      
+      this.logger.debug({ email: email.value }, 'User found successfully');
+      return Result.ok(user);
+
+    } catch (error) {
+      this.logger.error({
+        error: error instanceof Error ? error.message : 'Unknown error',
+        email: email.value,
+      }, 'Error finding user by email');
+
+      return Result.fail(
+        new DomainError(
+          'USER_REPOSITORY_ERROR',
+          'Failed to find user by email',
+          ErrorType.INTERNAL
+        )
+      );
+    }
+  }
+
+  /**
+   * ユーザーの保存（新規作成）
+   */
+  async save(user: User): Promise<Result<void>> {
+    try {
+      this.logger.debug({ userId: user.id.value }, 'Saving new user');
+
+      // Supabase Authでユーザーを作成
+      const result = await this.authAdapter.createUser({
+        id: user.id.value,
+        email: user.email.value,
+        email_confirmed: user.emailVerified,
+        app_metadata: {
+          tier: user.tier.level.toLowerCase(), // Supabaseには小文字で保存（例: 'tier1'）
+        },
+        user_metadata: user.metadata || {},
+      });
+
+      if (!result) {
+        return Result.fail(
+          new DomainError(
+            'USER_CREATION_FAILED',
+            'Failed to create user in Supabase',
+            ErrorType.INTERNAL
+          )
+        );
+      }
+
+      this.logger.info({ userId: user.id.value }, 'User saved successfully');
+      return Result.ok();
+
+    } catch (error) {
+      this.logger.error({
+        error: error instanceof Error ? error.message : 'Unknown error',
+        userId: user.id.value,
+      }, 'Error saving user');
+
+      return Result.fail(
+        new DomainError(
+          'USER_REPOSITORY_ERROR',
+          'Failed to save user',
+          ErrorType.INTERNAL
+        )
+      );
+    }
+  }
+
+  /**
+   * ユーザーの更新
+   */
+  async update(user: User): Promise<Result<void>> {
+    try {
+      this.logger.debug({ userId: user.id.value }, 'Updating user');
+
+      // Supabase Authでユーザーを更新
+      const result = await this.authAdapter.updateUser(user.id.value, {
+        email: user.email.value,
+        email_confirmed: user.emailVerified,
+        app_metadata: {
+          tier: user.tier.level.toLowerCase(), // Supabaseには小文字で保存（例: 'tier1'）
+        },
+        user_metadata: user.metadata || {},
+      });
+
+      if (!result) {
+        return Result.fail(
+          new DomainError(
+            'USER_UPDATE_FAILED',
+            'Failed to update user in Supabase',
+            ErrorType.INTERNAL
+          )
+        );
+      }
+
+      this.logger.info({ userId: user.id.value }, 'User updated successfully');
+      return Result.ok();
+
+    } catch (error) {
+      this.logger.error({
+        error: error instanceof Error ? error.message : 'Unknown error',
+        userId: user.id.value,
+      }, 'Error updating user');
+
+      return Result.fail(
+        new DomainError(
+          'USER_REPOSITORY_ERROR',
+          'Failed to update user',
+          ErrorType.INTERNAL
+        )
+      );
+    }
+  }
+
+  /**
+   * ユーザーの削除
+   */
+  async delete(id: UserId): Promise<Result<void>> {
+    try {
+      this.logger.debug({ userId: id.value }, 'Deleting user');
+
+      // Supabase Authからユーザーを削除
+      const result = await this.authAdapter.deleteUser(id.value);
+
+      if (!result) {
+        return Result.fail(
+          new DomainError(
+            'USER_DELETION_FAILED',
+            'Failed to delete user from Supabase',
+            ErrorType.INTERNAL
+          )
+        );
+      }
+
+      this.logger.info({ userId: id.value }, 'User deleted successfully');
+      return Result.ok();
+
+    } catch (error) {
+      this.logger.error({
+        error: error instanceof Error ? error.message : 'Unknown error',
+        userId: id.value,
+      }, 'Error deleting user');
+
+      return Result.fail(
+        new DomainError(
+          'USER_REPOSITORY_ERROR',
+          'Failed to delete user',
+          ErrorType.INTERNAL
+        )
+      );
+    }
+  }
+
+  /**
+   * SupabaseユーザーからドメインUserへのマッピング
+   */
+  private async mapToDomainUser(supabaseUser: any): Promise<User | null> {
+    try {
+      this.logger.debug({
+        supabaseUser,
+      }, 'Mapping Supabase user to domain model');
+
+      // UserIdの作成
+      const userIdResult = UserId.create(supabaseUser.id);
+      if (userIdResult.isFailure) {
+        this.logger.error({
+          userId: supabaseUser.id,
+          error: userIdResult.getError().message,
+        }, 'Invalid user ID format');
+        return null;
+      }
+      const userId = userIdResult.getValue();
+
+      // Emailの作成
+      const emailResult = Email.create(supabaseUser.email || '');
+      if (emailResult.isFailure) {
+        this.logger.error({
+          email: supabaseUser.email,
+          error: emailResult.getError().message,
+        }, 'Invalid email format');
+        return null;
+      }
+      const email = emailResult.getValue();
+
+      // UserTierの作成
+      // Supabaseから取得したtier値を正規化（例: 'tier1' -> 'TIER1'）
+      const rawTier = supabaseUser.app_metadata?.tier || 'tier1';
+      const tierLevel = rawTier.toUpperCase() as TierLevel;
+      const tierResult = UserTier.create(tierLevel);
+      if (tierResult.isFailure) {
+        this.logger.error({
+          tier: tierLevel,
+          rawTier: rawTier,
+          error: tierResult.getError().message,
+        }, 'Invalid tier level');
+        return null;
+      }
+      const tier = tierResult.getValue();
+
+      // ユーザーエンティティの再構築
+      const userProps: UserProps & { id: UserId } = {
+        id: userId,
+        email: email,
+        tier: tier,
+        createdAt: new Date(supabaseUser.created_at),
+        updatedAt: new Date(supabaseUser.updated_at || supabaseUser.created_at),
+        lastAuthenticatedAt: supabaseUser.last_sign_in_at 
+          ? new Date(supabaseUser.last_sign_in_at)
+          : undefined,
+        emailVerified: supabaseUser.email_confirmed_at !== null,
+        metadata: supabaseUser.user_metadata || {},
+      };
+
+      return User.reconstruct(userProps);
+    } catch (error) {
+      this.logger.error({
+        error: error instanceof Error ? error.message : 'Unknown error',
+        userId: supabaseUser?.id,
+      }, 'Failed to map Supabase user to domain model');
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
## 概要
UserRepositoryを実装し、Supabase Authとの連携を確立しました。これにより認証機能の基盤が整備されました。

## 実装内容
- IUserRepositoryインターフェースの定義
- Userエンティティの実装（Entity基底クラスを継承）
- Emailバリューオブジェクトの実装（メールアドレス検証付き）
- SupabaseUserRepositoryの実装
  - Supabase Authとの完全な連携
  - ドメインモデルへの双方向マッピング
  - ティアレベルの正規化（tier1 <-> TIER1）
- IAuthAdapterへのユーザー管理メソッド追加
- MockSupabaseAuthAdapterの拡張

## テスト結果
- UserRepositoryテスト：13/13 ✅
- データルートテスト：4/7（認証は成功するようになったが、別の問題が残存）

## 次のステップ
データルートテストを完全に修正するには、以下の実装が必要です：
- レスポンスボディの問題の修正
- エラーハンドリングの改善

🤖 Generated with [Claude Code](https://claude.ai/code)